### PR TITLE
Cmd history

### DIFF
--- a/examples/demo_linux/shell.c
+++ b/examples/demo_linux/shell.c
@@ -32,16 +32,25 @@ SOFTWARE.
 #include "commands.h"
 #include "fs/fs.h"
 
+#define SHELL_HISTORY_LINES     6       /* Must be at least >= 2 */
 #define SHELL_WORK_BUFFER_SIZE  256
 #define SHELL_HOSTNAME_SIZE     16
 
 static char g_hostname_data[SHELL_HOSTNAME_SIZE + 1];
+
+static char g_history_buf[SHELL_HISTORY_LINES * SHELL_WORK_BUFFER_SIZE];
+static ush_history g_history = {
+        .lines = SHELL_HISTORY_LINES,
+        .length = SHELL_WORK_BUFFER_SIZE,
+        .buffer = g_history_buf,
+};
 
 static char g_input_buffer[SHELL_WORK_BUFFER_SIZE];
 static char g_output_buffer[SHELL_WORK_BUFFER_SIZE];
 
 static const struct ush_descriptor g_ush_desc = {
         .io = &g_ush_io_interface,
+        .input_history = &g_history,
         .input_buffer = g_input_buffer,
         .input_buffer_size = sizeof(g_input_buffer),
         .output_buffer = g_output_buffer,

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,7 @@ file(
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ush_prompt.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ush_reset.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ush_file.c
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/ush_history.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ush_node.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ush_node_utils.c
     ${CMAKE_CURRENT_SOURCE_DIR}/src/ush_node_mount.c

--- a/src/inc/ush_history.h
+++ b/src/inc/ush_history.h
@@ -22,46 +22,26 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#ifndef USH_HISTORY_H
+#define USH_HISTORY_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 #include "inc/ush_internal.h"
-#include "inc/ush_const.h"
-#include "inc/ush_history.h"
-#include "inc/ush.h"
 
-#include <string.h>
+/* Calculates character index in the history buffer */
+#define HLINE_IDX(line)      ((line) * self->desc->input_history->length)
 
-void ush_reset_start(struct ush_object *self)
-{
-        USH_ASSERT(self != NULL);
+void ush_history_reset(struct ush_object *self);
+int ush_history_read_char(struct ush_object *self, char *ch);
 
-        self->state = USH_STATE_RESET;
+void ush_history_load_line(struct ush_object *self, size_t hline_idx);
+void ush_history_save_line(struct ush_object *self, size_t hline_idx, bool new_history_line);
+
+#ifdef __cplusplus
 }
+#endif
 
-void ush_reset(struct ush_object *self)
-{
-        USH_ASSERT(self != NULL);
-        
-        self->current_node = self->root;
-        ush_history_reset(self);
-        ush_write_pointer(self, USH_NAME " " USH_VERSION "\r\n", USH_STATE_RESET_PROMPT);
-}
-
-bool ush_reset_service(struct ush_object *self)
-{
-        USH_ASSERT(self != NULL);
-
-        bool processed = true;
-
-        switch (self->state) {
-        case USH_STATE_RESET:
-                ush_write_pointer(self, "\r\n", USH_STATE_RESET_PROMPT);
-                break;
-        case USH_STATE_RESET_PROMPT:
-                ush_prompt_start(self, USH_STATE_READ_PREPARE);
-                break;
-        default:
-                processed = false;
-                break;
-        }
-
-        return processed;
-}
+#endif /* USH_HISTORY_H */

--- a/src/inc/ush_internal.h
+++ b/src/inc/ush_internal.h
@@ -36,6 +36,7 @@ extern "C" {
 
 void ush_read_start(struct ush_object *self);
 bool ush_read_char(struct ush_object *self);
+bool ush_read_char_buffer(struct ush_object *self);
 void ush_read_echo_service(struct ush_object *self, char ch);
 bool ush_read_char_by_escape_state(struct ush_object *self, char ch);
 bool ush_read_service(struct ush_object *self, bool *read);

--- a/src/inc/ush_types.h
+++ b/src/inc/ush_types.h
@@ -72,6 +72,7 @@ typedef enum {
 
         USH_STATE_READ_PREPARE,                         /**< Prepare to read char state */
         USH_STATE_READ_CHAR,                            /**< Read char from input interface state */
+        USH_STATE_READ_CHAR_BUFFER,                     /**< Read char from history buffer */
 
         USH_STATE_PARSE_PREPARE,                        /**< Prepare to parse command state */
         USH_STATE_PARSE_SEARCH_ARG,                     /**< Search for command arguments state */
@@ -233,6 +234,18 @@ struct ush_io_interface {
 };
 
 /**
+ * @brief History line information structure.
+ *
+ * This structure contains history line information.
+ * It should be placed in ROM, in case if runtime modification is not necessary.
+ */
+typedef struct ush_history {
+        size_t lines;                           /**< Number of lines in the history buffer */
+        size_t length;                          /**< Length of each line in the history buffer */
+        char *buffer;                           /**< Pointer to the whole history buffer */
+} ush_history;
+
+/**
  * @brief Shell main descriptor structure.
  * 
  * This structure contains shell-related information.
@@ -240,6 +253,7 @@ struct ush_io_interface {
  */
 struct ush_descriptor {
         struct ush_io_interface const *io;              /**< Pointer to IO interface structure */
+        ush_history *input_history;                     /**< Pointer to history typedef struct (used to recall cmd history) */
         char *input_buffer;                             /**< Pointer to input working buffer (used to prepare and parsing data) */
         size_t input_buffer_size;                       /**< Input working buffer size */
         char *output_buffer;                            /**< Pointer to output working buffer (used to prepare and printing data) */
@@ -263,6 +277,11 @@ struct ush_object {
         ush_state_t state;                              /**< Current FSM internal state */
         ush_state_t write_next_state;                   /**< FSM internal state set after write */
         ush_state_t prompt_next_state;                  /**< FSM internal state set after prompt */
+
+        char *history_buf;                              /**< Pointer to history data to write to output interface */
+        size_t history_backspace;                       /**< Current number of backspace characters to erase line */
+        size_t history_index;                           /**< Current history buffer line index */
+        size_t history_pos;                             /**< Current history data position during write to output interface */
 
         char *write_buf;                                /**< Pointer to data to write to output interface */
         size_t write_size;                              /**< Number of chars to write to output interface */

--- a/src/src/ush.c
+++ b/src/src/ush.c
@@ -35,6 +35,8 @@ void ush_init(struct ush_object *self, const struct ush_descriptor *desc)
         USH_ASSERT(self != NULL);
         USH_ASSERT(desc != NULL);
 
+        USH_ASSERT(desc->input_history != NULL);
+
         USH_ASSERT(desc->input_buffer != NULL);
         USH_ASSERT(desc->input_buffer_size > 0);
         USH_ASSERT(desc->output_buffer != NULL);

--- a/src/src/ush.c
+++ b/src/src/ush.c
@@ -34,6 +34,8 @@ void ush_init(struct ush_object *self, const struct ush_descriptor *desc)
         USH_ASSERT(self != NULL);
         USH_ASSERT(desc != NULL);
 
+        USH_ASSERT(desc->input_history != NULL);
+
         USH_ASSERT(desc->input_buffer != NULL);
         USH_ASSERT(desc->input_buffer_size > 0);
         USH_ASSERT(desc->output_buffer != NULL);

--- a/src/src/ush_autocomp_state.c
+++ b/src/src/ush_autocomp_state.c
@@ -22,6 +22,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 */
 
+#include "inc/ush_history.h"
 #include "inc/ush_internal.h"
 #include "inc/ush_preconfig.h"
 #include "inc/ush_utils.h"
@@ -36,6 +37,8 @@ void ush_autocomp_state_recall_suffix(struct ush_object *self)
         char *suffix = self->autocomp_input + strlen(self->autocomp_input) - self->autocomp_suffix_len;
         if (strlen(suffix) > 0) {
                 ush_write_pointer(self, suffix, USH_STATE_READ_CHAR);
+                /* Copy autocomp suffix to current line history */
+                strcat(&self->desc->input_history->buffer[HLINE_IDX(0)], suffix);
         } else {
                 ush_autocomp_prepare_candidates(self);
                 ush_write_pointer(self, "\r\n", USH_STATE_AUTOCOMP_CANDIDATES_PRINT);
@@ -89,6 +92,8 @@ void ush_autocomp_state_candidates_finish(struct ush_object *self)
                         strcpy(self->autocomp_input, self->autocomp_candidate_name);
                         self->in_pos = strlen(self->desc->input_buffer);
                         ush_write_pointer(self, suffix, USH_STATE_READ_CHAR);
+                        /* Copy autocomp suffix to current line history */
+                        strcat(&self->desc->input_history->buffer[HLINE_IDX(0)], suffix);
                         break;
                 }
                 default:

--- a/src/src/ush_history.c
+++ b/src/src/ush_history.c
@@ -1,0 +1,110 @@
+/*
+MIT License
+
+Copyright (c) 2021 Marcin Borowicz <marcinbor85@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+*/
+
+#include "inc/ush_history.h"
+#include "inc/ush_internal.h"
+#include "inc/ush_preconfig.h"
+
+#include <stdarg.h>
+#include <string.h>
+
+void ush_history_reset(struct ush_object *self)
+{
+        /* Reset all history variables in ush_object */
+        self->history_buf = 0;
+        self->history_index = 0;
+        self->history_backspace = 0;
+        self->history_pos = 0;
+
+        /* Reset history buffer area */
+        memset(&self->desc->input_history->buffer[HLINE_IDX(0)], 0x00,
+               self->desc->input_history->lines * self->desc->input_history->length);
+}
+
+int ush_history_read_char(struct ush_object *self, char *ch)
+{
+        int ret = 0;
+
+        /* Start by returning backspace characters for current line */
+        if (self->history_backspace > 0) {
+                self->history_backspace--;
+                *ch = '\x08';
+                ret = 1;
+        }
+        /* Then continue returning history line characters for current line (except for \n and \r) */
+        else {
+                if (self->history_buf[self->history_pos] == '\n' ||
+                    self->history_buf[self->history_pos] == '\r') {
+                        self->history_pos++;
+                }
+                if (self->history_buf[self->history_pos] != 0x00) {
+                        *ch = self->history_buf[self->history_pos++];
+                        ret = 1;
+                }
+        }
+
+        return ret;
+}
+
+void ush_history_load_line(struct ush_object *self, size_t hline_idx)
+{
+        USH_ASSERT(self != NULL);
+
+        /* Setup erasing parameters for current line */
+        self->history_backspace = strlen(&self->desc->input_history->buffer[HLINE_IDX(0)]);
+        memset(&self->desc->input_history->buffer[0], 0x00,
+               self->desc->input_history->length);
+
+        /* Setup a history line as character input */
+        self->history_buf = &self->desc->input_history->buffer[HLINE_IDX(hline_idx)];
+        self->history_pos = 0;
+        self->state = USH_STATE_READ_CHAR_BUFFER;
+}
+
+void ush_history_save_line(struct ush_object *self, size_t hline_idx, bool new_history_line)
+{
+        USH_ASSERT(self != NULL);
+
+        /* Only save non-empty lines to history */
+        if (strlen(&self->desc->input_history->buffer[HLINE_IDX(0)]) > 1) {
+
+                /* Move out the oldest command line from history buffer? */
+                if (new_history_line) {
+                        for (size_t i = self->desc->input_history->lines - 1; i > 0; i--) {
+                        memcpy(&self->desc->input_history->buffer[HLINE_IDX(i)],
+                                &self->desc->input_history->buffer[HLINE_IDX(i - 1)],
+                                self->desc->input_history->length);
+                        }
+                        memset(&self->desc->input_history->buffer[HLINE_IDX(0)], 0x00,
+                               self->desc->input_history->length);
+                        self->history_index = 0;
+                }
+                else {
+                        /* Copy command line to history line */
+                        memcpy(&self->desc->input_history->buffer[HLINE_IDX(hline_idx)],
+                               &self->desc->input_history->buffer[HLINE_IDX(0)],
+                               self->desc->input_history->length);
+                }
+        }
+}

--- a/src/src/ush_read.c
+++ b/src/src/ush_read.c
@@ -13,6 +13,9 @@ bool ush_read_service(struct ush_object *self, bool *read)
         case USH_STATE_READ_CHAR:
                 *read = ush_read_char(self);
                 break;
+        case USH_STATE_READ_CHAR_BUFFER:
+                *read = ush_read_char_buffer(self);
+                break;
         default:
                 processed = false;
                 break;

--- a/src/src/ush_read_char.c
+++ b/src/src/ush_read_char.c
@@ -24,16 +24,11 @@ SOFTWARE.
 
 #include "inc/ush_internal.h"
 #include "inc/ush_preconfig.h"
+#include "inc/ush_history.h"
 
-bool ush_read_char(struct ush_object *self)
+static void ush_read_process(struct ush_object *self, char ch)
 {
-        USH_ASSERT(self != NULL);
-
-        char ch;
         bool echo = true;
-
-        if (self->desc->io->read(self, &ch) == 0)
-                return false;
         
         switch (ch) {
         case '\x03':
@@ -54,7 +49,10 @@ bool ush_read_char(struct ush_object *self)
         case '\x09':
                 /* tab */
 #if USH_CONFIG_ENABLE_FEATURE_AUTOCOMPLETE == 1      
-                ush_autocomp_start(self);
+                /* TODO: Implement autocomplete using history lines in the future */
+                if (self->history_index == 0) {
+                        ush_autocomp_start(self);
+                }
 #endif /* USH_CONFIG_ENABLE_FEATURE_AUTOCOMPLETE */
                 echo = false;
                 break;
@@ -70,6 +68,32 @@ bool ush_read_char(struct ush_object *self)
 
         if (echo != false)
                 ush_read_echo_service(self, ch);
+}
+
+bool ush_read_char(struct ush_object *self)
+{
+        USH_ASSERT(self != NULL);
+
+        char ch;
+        if (self->desc->io->read(self, &ch) == 0)
+                return false;
+
+        ush_read_process(self, ch);
+
+        return true;
+}
+
+bool ush_read_char_buffer(struct ush_object *self)
+{
+        USH_ASSERT(self != NULL);
         
+        char ch;
+        if (ush_history_read_char(self, &ch) == 0) {
+                self->state = USH_STATE_READ_CHAR;
+                return false;
+        }
+
+        ush_read_process(self, ch);
+
         return true;
 }

--- a/src/src/ush_read_char.c
+++ b/src/src/ush_read_char.c
@@ -58,6 +58,12 @@ static void ush_read_process(struct ush_object *self, char ch)
                 self->ansi_escape_state = 1;
                 echo = false;
                 break;
+        case '\x01':
+        case '\x1A':
+                /* ctrl+a or ctrl+z */
+                self->ansi_escape_state = 2;
+                echo = ush_read_char_by_escape_state(self, ch);
+                break;
         default:
                 echo = ush_read_char_by_escape_state(self, ch);
                 break;

--- a/src/src/ush_read_char.c
+++ b/src/src/ush_read_char.c
@@ -48,11 +48,8 @@ static void ush_read_process(struct ush_object *self, char ch)
                 break;
         case '\x09':
                 /* tab */
-#if USH_CONFIG_ENABLE_FEATURE_AUTOCOMPLETE == 1      
-                /* TODO: Implement autocomplete using history lines in the future */
-                if (self->history_index == 0) {
-                        ush_autocomp_start(self);
-                }
+#if USH_CONFIG_ENABLE_FEATURE_AUTOCOMPLETE == 1
+                ush_autocomp_start(self);
 #endif /* USH_CONFIG_ENABLE_FEATURE_AUTOCOMPLETE */
                 echo = false;
                 break;

--- a/src/src/ush_read_utils.c
+++ b/src/src/ush_read_utils.c
@@ -77,14 +77,14 @@ bool ush_read_char_by_escape_state(struct ush_object *self, char ch)
                 }
                 echo = false;
         } else if (self->ansi_escape_state == 2) {
-                if (ch == '\x41') {
+                if (ch == '\x41' || ch == '\x01') { /* up arrow or ctrl+a */
                         /* up - process if upper limit not reached and there is a historic line to move to */
                         if ((self->history_index < self->desc->input_history->lines - 1) &&
                             (strlen(&self->desc->input_history->buffer[HLINE_IDX(self->history_index + 1)]))) {
                                 self->history_index++;
                                 ush_history_load_line(self, self->history_index);
                         }
-                } else if (ch == '\x42') {
+                } else if (ch == '\x42' || ch == '\x1A') { /* down arrow or ctrl+z */
                         /* down - process if lower limit is not reached */
                          if (self->history_index > 0) {
                                 self->history_index--;

--- a/tests/func_tests/test_func.c
+++ b/tests/func_tests/test_func.c
@@ -26,6 +26,8 @@ SOFTWARE.
 
 #include "test_func.h"
 
+#define SHELL_HISTORY_LINES     6       /* Must be at least >= 2 */
+
 char g_read_buf[TEST_FUNC_IO_BUFFER_SIZE];
 char g_write_buf[TEST_FUNC_IO_BUFFER_SIZE];
 
@@ -62,6 +64,14 @@ static const struct ush_io_interface g_ush_io_interface = {
 };
 
 struct ush_object g_ush;
+
+static char g_history_buffer[SHELL_HISTORY_LINES * TEST_FUNC_WORK_BUFFER_SIZE];
+static ush_history g_history = {
+        .lines = SHELL_HISTORY_LINES,
+        .length = TEST_FUNC_WORK_BUFFER_SIZE,
+        .buffer = g_history_buffer,
+};
+
 static char g_input_buffer[TEST_FUNC_WORK_BUFFER_SIZE];
 static char g_output_buffer[TEST_FUNC_WORK_BUFFER_SIZE];
 
@@ -71,6 +81,7 @@ static char g_hostname_data[16] = {
 
 static const struct ush_descriptor g_ush_desc = {
         .io = &g_ush_io_interface,
+        .input_history = &g_history,
         .input_buffer = g_input_buffer,
         .input_buffer_size = sizeof(g_input_buffer),
         .output_buffer = g_output_buffer,

--- a/tests/unit_tests/CMakeLists.txt
+++ b/tests/unit_tests/CMakeLists.txt
@@ -31,11 +31,17 @@ create_unit_test( test_unit_read
 
 create_unit_test( test_unit_read_utils
     ${CMAKE_CURRENT_SOURCE_DIR}/test_unit_read_utils.c
+    # TODO: Make separate test unit for ush_history.c.
+    #       Right now, calling history functions from here is better than nothing
+    ${USH_SRC_DIR}/src/ush_history.c
     ${USH_SRC_DIR}/src/ush_read_utils.c
 )
 
 create_unit_test( test_unit_read_char
     ${CMAKE_CURRENT_SOURCE_DIR}/test_unit_read_char.c
+    # TODO: Make separate test unit for ush_history.c.
+    #       Right now, calling history functions from here is better than nothing
+    ${USH_SRC_DIR}/src/ush_history.c
     ${USH_SRC_DIR}/src/ush_read_char.c
 )
 

--- a/tests/unit_tests/test_unit_read.c
+++ b/tests/unit_tests/test_unit_read.c
@@ -35,7 +35,9 @@ struct ush_object ush;
 
 int ush_read_start_call_count;
 int ush_read_char_call_count;
+int ush_read_char_buffer_call_count;
 bool ush_read_char_return_val;
+bool ush_read_char_buffer_return_val;
 
 void setUp(void)
 {
@@ -57,6 +59,15 @@ void ush_read_start(struct ush_object *self)
         TEST_ASSERT_EQUAL(&ush, self);
 
         ush_read_start_call_count++;
+}
+
+bool ush_read_char_buffer(struct ush_object *self)
+{
+        TEST_ASSERT_EQUAL(&ush, self);
+
+        ush_read_char_buffer_call_count++;
+
+        return ush_read_char_buffer_return_val;
 }
 
 bool ush_read_char(struct ush_object *self)
@@ -86,6 +97,11 @@ void test_ush_read_service_state(void)
                         TEST_ASSERT_TRUE(ush_read_service(&ush, &read));
                         TEST_ASSERT_EQUAL(0, ush_read_start_call_count);
                         TEST_ASSERT_EQUAL(1, ush_read_char_call_count);
+                        break;
+                case USH_STATE_READ_CHAR_BUFFER:
+                        TEST_ASSERT_TRUE(ush_read_service(&ush, &read));
+                        TEST_ASSERT_EQUAL(0, ush_read_start_call_count);
+                        TEST_ASSERT_EQUAL(1, ush_read_char_buffer_call_count);
                         break;
                 default:
                         TEST_ASSERT_FALSE(ush_read_service(&ush, &read));

--- a/tests/unit_tests/test_unit_read_utils.c
+++ b/tests/unit_tests/test_unit_read_utils.c
@@ -29,10 +29,20 @@ SOFTWARE.
 
 #include "inc/ush_internal.h"
 
+#define SHELL_HISTORY_LINES     6       /* Must be at least >= 2 */
+#define SHELL_WORK_BUFFER_SIZE  128
+
 int g_assert_call_count;
 
-char input_buffer[128];
-char output_buffer[128];
+static char g_history_buffer[SHELL_HISTORY_LINES * SHELL_WORK_BUFFER_SIZE];
+static ush_history g_history = {
+        .lines = SHELL_HISTORY_LINES,
+        .length = SHELL_WORK_BUFFER_SIZE,
+        .buffer = g_history_buffer,
+};
+
+char input_buffer[SHELL_WORK_BUFFER_SIZE];
+char output_buffer[SHELL_WORK_BUFFER_SIZE];
 
 struct ush_descriptor ush_desc;
 struct ush_object ush;
@@ -42,6 +52,7 @@ char ush_read_echo_service_char;
 
 void setUp(void)
 {
+        ush_desc.input_history = &g_history;
         ush_desc.input_buffer = input_buffer;
         ush_desc.input_buffer_size = sizeof(input_buffer);
         ush_desc.output_buffer = output_buffer;
@@ -85,6 +96,9 @@ void test_ush_read_echo_service(void)
 {
         for (int i = 0; i < 256; i++) {
                 setUp();
+
+                /* TODO: Add unit test for state USH_STATE_READ_CHAR_BUFFER */
+                ush.state = USH_STATE_READ_CHAR;
 
                 char ch = (char)i;
                 ush_read_echo_service_char = ch;

--- a/tests/unit_tests/test_unit_reset.c
+++ b/tests/unit_tests/test_unit_reset.c
@@ -35,6 +35,7 @@ int g_assert_call_count;
 
 struct ush_object ush;
 
+int ush_history_reset_call_count;
 int ush_write_pointer_call_count;
 int ush_prompt_start_call_count;
 
@@ -57,6 +58,13 @@ void setUp(void)
 void tearDown(void)
 {
 
+}
+
+void ush_history_reset(struct ush_object *self)
+{
+        TEST_ASSERT_EQUAL(&ush, self);
+
+        ush_history_reset_call_count++;
 }
 
 void ush_write_pointer(struct ush_object *self, char *text, ush_state_t state)
@@ -84,6 +92,7 @@ void test_ush_reset(void)
         ush_reset(&ush);
         TEST_ASSERT_EQUAL((struct ush_node_object*)1234, ush.current_node);
         TEST_ASSERT_EQUAL(USH_STATE_RESET, ush.state);
+        TEST_ASSERT_EQUAL(1, ush_history_reset_call_count);
         TEST_ASSERT_EQUAL(1, ush_write_pointer_call_count);
         TEST_ASSERT_EQUAL(0, ush_prompt_start_call_count);
 }

--- a/tests/unit_tests/test_unit_ush.c
+++ b/tests/unit_tests/test_unit_ush.c
@@ -228,7 +228,7 @@ void test_ush_init(void)
                 case USH_STATUS_OK:
                         TEST_ASSERT_EQUAL(&ush_desc, ush.desc);
                         TEST_ASSERT_NULL(ush.root);
-                        TEST_ASSERT_EQUAL(7, g_assert_call_count);
+                        TEST_ASSERT_EQUAL(8, g_assert_call_count);
                         TEST_ASSERT_EQUAL(1, ush_commands_add_call_count);
                         TEST_ASSERT_EQUAL(1, ush_reset_call_count);
                         TEST_ASSERT_EQUAL(0, ush_write_pointer_call_count);
@@ -245,7 +245,7 @@ void test_ush_init(void)
                 default:
                         TEST_ASSERT_EQUAL(&ush_desc, ush.desc);
                         TEST_ASSERT_NULL(ush.root);
-                        TEST_ASSERT_EQUAL(8, g_assert_call_count);
+                        TEST_ASSERT_EQUAL(9, g_assert_call_count);
                         TEST_ASSERT_EQUAL(1, ush_commands_add_call_count);
                         TEST_ASSERT_EQUAL(1, ush_reset_call_count);
                         TEST_ASSERT_EQUAL(0, ush_write_pointer_call_count);


### PR DESCRIPTION
Implement command history with either up/down arrows or ctrl+a/ctrl+z. The control key combos are added because they send only a single byte, whereas up/down arrows send 3 bytes - on some systems the character processing may not be fast enough to digest the full escape codes.